### PR TITLE
refactor: 이미지텍스트에서 브랜드값을 추출해오는 로직을 수정함.

### DIFF
--- a/GiftWallet/GiftWallet/UseCase/AutoInputUseCase.swift
+++ b/GiftWallet/GiftWallet/UseCase/AutoInputUseCase.swift
@@ -12,16 +12,14 @@ struct AutoInputUseCase {
     //MARK: Texts To Brand
     func processImageTextsToBrandNameText(imageTexts: [String]?) -> String? {
         var brandName: String?
-        let brandList = BrandList()
+        let brandList = BrandList().lists
         
         guard let imageTexts = imageTexts else { return nil }
-        let trimmingImageTexts = imageTexts.map( { $0.replacingOccurrences(of: " ", with: "") })
-        print(trimmingImageTexts)
-        
-        for list in brandList.lists {
-            if trimmingImageTexts.contains(list) {
-                brandName = list
-            }
+        let separatedTexts = imageTexts.flatMap { $0.components(separatedBy: " ") }
+        let removedPunctuationTexts = separatedTexts.map { $0.components(separatedBy: CharacterSet.alphanumerics.inverted).joined() }
+                
+        if let brand = removedPunctuationTexts.first(where: { brandList.contains($0.lowercased()) }) {
+            brandName = brand
         }
         return brandName
     }


### PR DESCRIPTION
### 수정로직

1. imageTexts(공백포함문자) 를 “ ”를 기준으로 sort 함수로 나눠준다.
2. 배열의 모든 요소에 공백 + 특수문자를 제거한다.
3. 그 안에서 brandList와 일치하는 것을 찾고 그것을 반환하도록 함