### PR TITLE
[Fix] 계정 로그아웃 후 재 로그인 시 Data 일치하지 않는오류 해결 

### DIFF
--- a/GiftWallet/GiftWallet/Manager/CoreDataManager.swift
+++ b/GiftWallet/GiftWallet/Manager/CoreDataManager.swift
@@ -120,14 +120,11 @@ final class CoreDataManager {
         try context.execute(deleteRequest)
         try context.save()
         
-        var giftDataMostRecentNumber = 0
-        
         let entity = NSEntityDescription.entity(forEntityName: "GiftData", in: context)
         for gift in gifts {
             if let entity = entity {
                 let info = NSManagedObject(entity: entity, insertInto: context)
-                giftDataMostRecentNumber += 1
-                info.setValue(giftDataMostRecentNumber, forKey: "number")
+                info.setValue(gift.number, forKey: "number")
                 info.setValue(gift.image.pngData(), forKey: "image")
                 info.setValue(gift.category?.rawValue, forKey: "category")
                 info.setValue(gift.brandName, forKey: "brandName")

--- a/GiftWallet/GiftWallet/Manager/FireBaseManager/FireBaseManager.swift
+++ b/GiftWallet/GiftWallet/Manager/FireBaseManager/FireBaseManager.swift
@@ -315,7 +315,7 @@ extension FireBaseManager {
         
         self.downLoadImageData(dataNumber: number) { data in
             if let image = UIImage(data: data) {
-                let gift = Gift(
+                var gift = Gift(
                     image: image,
                     category: category as? Category,
                     brandName: brandName,
@@ -325,6 +325,7 @@ extension FireBaseManager {
                     expireDate: expireDate,
                     useDate: useDate
                 )
+                gift.number = number
                 completion(gift)
             }
         }


### PR DESCRIPTION
Kakao 로그인에서 기존의 데이터들을 등록된 상태로
LogOut -> Login 과정을 거치면
Firebase에 올라와 있는 Number값과, Coredata에 받아진 Number값이 달라져,
새로운 값을 등록 할 때 비정상적으로 등록 되는 현상 수정